### PR TITLE
Include llvm-tools-preview when describing build prerequisites.

### DIFF
--- a/boards/rp-pico/README.md
+++ b/boards/rp-pico/README.md
@@ -26,9 +26,10 @@ cargo build --target thumbv6m-none-eabi --example=blink  --release
 
 To flash the program, you must convert the ELF executable to a UF2 image.
 
-Install [`uf2conv`](https://github.com/sajattack/uf2conv-rs) and [`cargo-binutils`](https://github.com/rust-embedded/cargo-binutils):
+Install [`uf2conv`](https://github.com/sajattack/uf2conv-rs) and [`cargo-binutils`](https://github.com/rust-embedded/cargo-binutils) as well as the `llvm-tools-preview` component :
 ``` sh
 cargo install uf2conv cargo-binutils
+rustup component add llvm-tools-preview
 ```
 
 Convert the ELF executable to a binary image:


### PR DESCRIPTION
This fixes an error when executing `cargo objcopy --example blink --release -- -O binary blink.bin`. The error appears both on Ubuntu and MacOs:

```
Failed to execute tool: objcopy
No such file or directory (os error 2)
```

Installing the `llvm-tools-preview` component fixes the issue.